### PR TITLE
fix: allow npm run dev without Auth0 env vars

### DIFF
--- a/src/components/auth/AuthProviderWithRedirect.tsx
+++ b/src/components/auth/AuthProviderWithRedirect.tsx
@@ -2,15 +2,18 @@ import { Auth0Provider } from "@auth0/auth0-react";
 import type { FC, PropsWithChildren } from "react";
 import { useNavigate } from "react-router-dom";
 
-const domain = import.meta.env.VITE_AUTH_DOMAIN as string | undefined;
-const clientId = import.meta.env.VITE_AUTH_CLIENT_ID as string | undefined;
-const redirectUri = import.meta.env.VITE_AUTH_REDIRECT_URL as string | undefined;
+type Props = {
+  domain: string;
+  clientId: string;
+  redirectUri: string;
+};
 
-if (!domain || !clientId || !redirectUri) {
-  throw new Error("Missing environment variables");
-}
-
-const Auth0ProviderWithRedirect: FC<PropsWithChildren<object>> = ({ children }) => {
+const Auth0ProviderWithRedirect: FC<PropsWithChildren<Props>> = ({
+  children,
+  domain,
+  clientId,
+  redirectUri,
+}) => {
   const navigate = useNavigate();
 
   const onRedirectCallback = async () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,23 @@ import LandingPage from "./pages/LandingPage.tsx";
 
 const queryClient = new QueryClient();
 
+const domain = import.meta.env.VITE_AUTH_DOMAIN as string | undefined;
+const clientId = import.meta.env.VITE_AUTH_CLIENT_ID as string | undefined;
+const redirectUri = import.meta.env.VITE_AUTH_REDIRECT_URL as string | undefined;
+
+if (!domain || !clientId || !redirectUri) {
+  const missing = [
+    !domain && "VITE_AUTH_DOMAIN",
+    !clientId && "VITE_AUTH_CLIENT_ID",
+    !redirectUri && "VITE_AUTH_REDIRECT_URL",
+  ]
+    .filter(Boolean)
+    .join(", ");
+  console.warn(
+    `Missing ${missing}. Auth0 is disabled for this dev session — routes requiring auth will not work. See .env.template.`,
+  );
+}
+
 const router = createBrowserRouter([
   {
     path: "/",
@@ -21,35 +38,43 @@ const router = createBrowserRouter([
       </QueryClientProvider>
     ),
   },
-  {
-    path: "/:envId",
-    element: (
-      <Auth0ProviderWithRedirect>
-        <QueryClientProvider client={queryClient}>
-          <ErrorBoundary
-            fallbackRender={({ error }) => (
-              <div>
-                There was an error!{" "}
-                <pre>{error instanceof Error ? error.message : String(error)}</pre>
-              </div>
-            )}
-          >
-            <Suspense
-              fallback={
-                <div className="flex w-screen h-screen justify-center">
-                  <Loader />
-                </div>
-              }
+  ...(domain && clientId && redirectUri
+    ? [
+        {
+          path: "/:envId",
+          element: (
+            <Auth0ProviderWithRedirect
+              domain={domain}
+              clientId={clientId}
+              redirectUri={redirectUri}
             >
-              <AppContextComponent>
-                <LandingPage />
-              </AppContextComponent>
-            </Suspense>
-          </ErrorBoundary>
-        </QueryClientProvider>
-      </Auth0ProviderWithRedirect>
-    ),
-  },
+              <QueryClientProvider client={queryClient}>
+                <ErrorBoundary
+                  fallbackRender={({ error }) => (
+                    <div>
+                      There was an error!{" "}
+                      <pre>{error instanceof Error ? error.message : String(error)}</pre>
+                    </div>
+                  )}
+                >
+                  <Suspense
+                    fallback={
+                      <div className="flex w-screen h-screen justify-center">
+                        <Loader />
+                      </div>
+                    }
+                  >
+                    <AppContextComponent>
+                      <LandingPage />
+                    </AppContextComponent>
+                  </Suspense>
+                </ErrorBoundary>
+              </QueryClientProvider>
+            </Auth0ProviderWithRedirect>
+          ),
+        },
+      ]
+    : []),
 ]);
 
 const root = document.getElementById("root");


### PR DESCRIPTION
Move Auth0 env reads from AuthProviderWithRedirect into main.tsx and pass domain, clientId, redirectUri as props. When any of VITE_AUTH_DOMAIN / VITE_AUTH_CLIENT_ID / VITE_AUTH_REDIRECT_URL is missing, the /:envId route is no longer registered and a console warning names the missing vars, so the dev server can boot without a populated .env.

### Motivation

Which issue does this fix? Fixes #`issue number`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?